### PR TITLE
fix: fix typo in route

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -1578,7 +1578,7 @@ class SidechatAPIClient {
       throw new SidechatAPIError("User is not authenticated.");
     }
     try {
-      const res = await fetch(`${this.apiRoot}/v1/posts/hide_post_from_user`, {
+      const res = await fetch(`${this.apiRoot}/v1/posts/hide_posts_from_user`, {
         method: "POST",
         headers: {
           ...this.defaultHeaders,

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1574,7 +1574,7 @@ class SidechatAPIClient {
       throw new SidechatAPIError("User is not authenticated.");
     }
     try {
-      const res = await fetch(`${this.apiRoot}/v1/posts/hide_post_from_user`, {
+      const res = await fetch(`${this.apiRoot}/v1/posts/hide_posts_from_user`, {
         method: "POST",
         headers: {
           ...this.defaultHeaders,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sidechat.js",
-  "version": "2.6.2",
+  "version": "2.6.3",
   "description": "A reverse-engineered API wrapper for Sidechat",
   "type": "module",
   "source": "./src/index.js",

--- a/src/classes/SidechatAPIClient.js
+++ b/src/classes/SidechatAPIClient.js
@@ -1362,7 +1362,7 @@ class SidechatAPIClient {
       throw new SidechatAPIError("User is not authenticated.");
     }
     try {
-      const res = await fetch(`${this.apiRoot}/v1/posts/hide_post_from_user`, {
+      const res = await fetch(`${this.apiRoot}/v1/posts/hide_posts_from_user`, {
         method: "POST",
         headers: {
           ...this.defaultHeaders,


### PR DESCRIPTION
Embarrassing typo here... but this is confirmed to be working now instead of returning `{ error: 'Route not found' }`. (Unhide all also works, confirmed)